### PR TITLE
Add setup requirements to fix downstream issues with version number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
-  number: 2
+  number: 3
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ requirements:
   host:
     - pip
     - python
+    - setuptools >=45
+    - setuptools-scm >=6.0.1
   run:
     - importlib-metadata  # [py<38]
     - python


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
If a downstream package depends on this package and executes `pip check` it fails as the version cannot be determined without `setuptools-scm`. This PR updates the requirements.

<!--
Please add any other relevant info below:
-->
